### PR TITLE
Automatically link to preview-code 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -53,3 +53,4 @@ server.crt
 server.csr
 server.key
 server.pkcs12
+*.pem

--- a/pom.xml
+++ b/pom.xml
@@ -30,6 +30,36 @@
           <version>[3.0.0,)</version>
         </dependency>
 
+        <!-- For calling GitHub APIs that are still in preview -->
+        <dependency>
+            <groupId>com.squareup.okhttp3</groupId>
+            <artifactId>okhttp</artifactId>
+            <version>3.7.0</version>
+        </dependency>
+
+        <!-- For authenticating our Integration & Installation with GitHub -->
+        <dependency>
+            <groupId>com.auth0</groupId>
+            <artifactId>java-jwt</artifactId>
+            <version>3.1.0</version>
+        </dependency>
+
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-annotations</artifactId>
+            <version>2.8.8</version>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-annotations</artifactId>
+            <version>2.8.8</version>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-core</artifactId>
+            <version>2.8.8</version>
+        </dependency>
+
         <!-- JAX-RS -->
         <dependency>
             <groupId>org.jboss.resteasy</groupId>

--- a/src/main/java/previewcode/backend/DTO/WebhookPullRequest.java
+++ b/src/main/java/previewcode/backend/DTO/WebhookPullRequest.java
@@ -1,0 +1,51 @@
+package previewcode.backend.DTO;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+@JsonIgnoreProperties(ignoreUnknown=true)
+public class WebhookPullRequest {
+
+    @JsonProperty("body")
+    public final String body;
+
+    @JsonIgnore
+    public final String url;
+
+    @JsonIgnore
+    public final String title;
+
+    @JsonIgnore
+    public final Integer number;
+
+    @JsonCreator
+    public WebhookPullRequest(
+            @JsonProperty("title") String title,
+            @JsonProperty("body") String body,
+            @JsonProperty("url") String url,
+            @JsonProperty("number") Integer number) {
+        this.title = title;
+        this.body = body;
+        this.url = url;
+        this.number = number;
+    }
+
+    public WebhookPullRequest addPreviewCodeSignature(WebhookRepo repo) {
+        if (this.body.contains("[//]: # (PREVIEW_CODE_BEGIN_SIGNATURE)")) {
+            return this;
+        } else {
+            return new WebhookPullRequest(this.title, this.body + this.getSignatureMarkdown(repo), this.url, this.number);
+        }
+    }
+
+    private String getSignatureMarkdown(WebhookRepo repo) {
+        return "\n" +
+                "\n" +
+                "[//]: # (PREVIEW_CODE_BEGIN_SIGNATURE)\n" +
+                "\n" +
+                "---\n" +
+                "Review this pull request [on Preview Code](https://preview-code.com/projects/" + repo.fullName + "/pulls/" + this.number + "/overview).";
+    }
+}

--- a/src/main/java/previewcode/backend/DTO/WebhookRepo.java
+++ b/src/main/java/previewcode/backend/DTO/WebhookRepo.java
@@ -1,0 +1,16 @@
+package previewcode.backend.DTO;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+@JsonIgnoreProperties(ignoreUnknown=true)
+public class WebhookRepo {
+
+    public final String fullName;
+
+    @JsonCreator
+    public WebhookRepo(@JsonProperty("full_name") String name) {
+        this.fullName = name;
+    }
+}

--- a/src/main/java/previewcode/backend/api/v1/WebhookAPI.java
+++ b/src/main/java/previewcode/backend/api/v1/WebhookAPI.java
@@ -1,0 +1,76 @@
+package previewcode.backend.api.v1;
+
+import com.auth0.jwt.JWT;
+import com.auth0.jwt.algorithms.Algorithm;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import okhttp3.*;
+import previewcode.backend.DTO.WebhookPullRequest;
+import previewcode.backend.DTO.WebhookRepo;
+
+import javax.inject.Inject;
+import javax.ws.rs.POST;
+import javax.ws.rs.Path;
+import java.io.IOException;
+import java.security.NoSuchAlgorithmException;
+import java.security.spec.InvalidKeySpecException;
+import java.util.Calendar;
+import java.util.Date;
+
+
+@Path("webhook/")
+public class WebhookAPI {
+
+    @Inject
+    private Algorithm jwtSigningAlgorithm;
+
+    private static final String INTEGRATION_ID = "2112";
+    private static final RequestBody EMPTY_REQUEST_BODY = RequestBody.create(null, new byte[]{});
+    private static final OkHttpClient OK_HTTP_CLIENT = new OkHttpClient();
+    private static final ObjectMapper mapper = new ObjectMapper();
+
+    @POST
+    public void onWebhookPost(String postData) throws IOException, NoSuchAlgorithmException, InvalidKeySpecException {
+        JsonNode body = mapper.readTree(postData);
+
+        if (body.get("action").asText().equals("opened")) {
+            String installationId = body.get("installation").get("id").asText();
+
+            Calendar calendar = Calendar.getInstance();
+            Date now = calendar.getTime();
+            calendar.add(Calendar.MINUTE, 10);
+            Date exp = calendar.getTime();
+
+            String token = JWT.create()
+                    .withIssuedAt(now)
+                    .withExpiresAt(exp)
+                    .withIssuer(INTEGRATION_ID)
+                    .sign(jwtSigningAlgorithm);
+
+            Request request = new Request.Builder()
+                    .url("https://api.github.com/installations/" + installationId + "/access_tokens")
+                    .addHeader("Accept", "application/vnd.github.machine-man-preview+json")
+                    .addHeader("Authorization", "Bearer " + token)
+                    .post(EMPTY_REQUEST_BODY)
+                    .build();
+            Response response = OK_HTTP_CLIENT.newCall(request).execute();
+            String installationToken = mapper.readValue(response.body().string(), JsonNode.class)
+                    .get("token").asText();
+
+            WebhookRepo repo = mapper.treeToValue(body.get("repository"), WebhookRepo.class);
+            WebhookPullRequest editedPull = mapper.treeToValue(body.get("pull_request"), WebhookPullRequest.class)
+                    .addPreviewCodeSignature(repo);
+
+            RequestBody editPullBody = RequestBody.create(MediaType.parse("application/json"), mapper.writeValueAsString(editedPull));
+
+            Request editPull = new Request.Builder()
+                    .url(editedPull.url)
+                    .addHeader("Accept", "application/vnd.github.machine-man-preview+json")
+                    .addHeader("Authorization", "token " + installationToken)
+                    .patch(editPullBody)
+                    .build();
+
+            OK_HTTP_CLIENT.newCall(editPull).execute();
+        }
+    }
+}

--- a/src/main/webapp/WEB-INF/web.xml
+++ b/src/main/webapp/WEB-INF/web.xml
@@ -1,6 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<web-app version="2.5" xmlns="http://java.sun.com/xml/ns/javaee" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://java.sun.com/xml/ns/javaee http://java.sun.com/xml/ns/javaee/web-app_2_5.xsd">
+<web-app metadata-complete="true" version="2.5" xmlns="http://java.sun.com/xml/ns/javaee" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://java.sun.com/xml/ns/javaee http://java.sun.com/xml/ns/javaee/web-app_2_5.xsd">
 
+    <absolute-ordering>
+        <name>dummy</name>
+    </absolute-ordering>
     <display-name>Preview-code backend</display-name>
 
     <context-param>


### PR DESCRIPTION
The back-end now responds to an `integration` webhook when a PR is opened on Github. If not yet present, the back-end will place a link to the PR on preview-code at the bottom of the PR description.

Things to be done in the very near future (in other PRs):
 - Do not hard-code integration id
 - Improve security with respect to handling of RSA keys
 - Verify that the call originates from GitHub
 - Upgrade this to use the `statuses` API. 

This last point is interesting as we can than reflect whether all reviewers have approved via a status. It's also less hacky compared to editing the PR description.  

---
Review this pull request [on Preview Code](https://preview-code.com/projects/preview-code/backend/pulls/24/overview).