### PR TITLE
Remove userid from tracking logs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -54,3 +54,4 @@ server.csr
 server.key
 server.pkcs12
 *.pem
+*.txt

--- a/src/main/java/previewcode/backend/DTO/Track.java
+++ b/src/main/java/previewcode/backend/DTO/Track.java
@@ -5,11 +5,6 @@ package previewcode.backend.DTO;
  */
 public class Track {
     /**
-     * The id of the user
-     */
-    public String userID;
-
-    /**
      * The new location of the current user
      */
     public String newPath;

--- a/src/main/java/previewcode/backend/api/v1/PullRequestAPI.java
+++ b/src/main/java/previewcode/backend/api/v1/PullRequestAPI.java
@@ -1,11 +1,6 @@
 package previewcode.backend.api.v1;
 
-import javax.ws.rs.Consumes;
-import javax.ws.rs.POST;
-import javax.ws.rs.Path;
-import javax.ws.rs.PathParam;
-import javax.ws.rs.core.MediaType;
-
+import com.google.inject.Inject;
 import previewcode.backend.DTO.Ordering;
 import previewcode.backend.DTO.PRbody;
 import previewcode.backend.DTO.PrNumber;
@@ -13,8 +8,11 @@ import previewcode.backend.DTO.StatusBody;
 import previewcode.backend.services.FirebaseService;
 import previewcode.backend.services.GithubService;
 
-import com.google.inject.Inject;
-
+import javax.ws.rs.Consumes;
+import javax.ws.rs.POST;
+import javax.ws.rs.Path;
+import javax.ws.rs.PathParam;
+import javax.ws.rs.core.MediaType;
 import java.util.List;
 
 @Path("{owner}/{name}/pulls/")

--- a/src/main/java/previewcode/backend/api/v1/TrackerAPI.java
+++ b/src/main/java/previewcode/backend/api/v1/TrackerAPI.java
@@ -1,14 +1,13 @@
 package previewcode.backend.api.v1;
 
+import com.google.inject.Inject;
+import previewcode.backend.DTO.Track;
+import previewcode.backend.services.FirebaseService;
+
 import javax.ws.rs.Consumes;
 import javax.ws.rs.POST;
 import javax.ws.rs.Path;
 import javax.ws.rs.core.MediaType;
-
-import previewcode.backend.DTO.Track;
-import previewcode.backend.services.FirebaseService;
-
-import com.google.inject.Inject;
 
 /**
  * API endpoint for the status of a pull request

--- a/src/main/java/previewcode/backend/services/FirebaseService.java
+++ b/src/main/java/previewcode/backend/services/FirebaseService.java
@@ -1,13 +1,5 @@
 package previewcode.backend.services;
 
-import java.util.ArrayList;
-import java.util.List;
-import java.util.function.Function;
-
-import previewcode.backend.DTO.Approve;
-import previewcode.backend.DTO.Ordering;
-import previewcode.backend.DTO.PrNumber;
-
 import com.google.firebase.database.DataSnapshot;
 import com.google.firebase.database.DatabaseError;
 import com.google.firebase.database.DatabaseReference;
@@ -18,7 +10,14 @@ import com.google.firebase.database.Transaction.Handler;
 import com.google.firebase.database.Transaction.Result;
 import com.google.firebase.database.ValueEventListener;
 import com.google.inject.Singleton;
+import previewcode.backend.DTO.Approve;
+import previewcode.backend.DTO.Ordering;
+import previewcode.backend.DTO.PrNumber;
 import previewcode.backend.DTO.Track;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.function.Function;
 
 /**
  * An abstract class that connects with firebase
@@ -172,7 +171,7 @@ public class FirebaseService {
     }
 
     public void addTracker(Track data) {
-        DatabaseReference path = this.ref.child("users").child(data.userID).child("tracker").child(data.time);
+        DatabaseReference path = this.ref.child("tracking").child(data.time);
         path.child("new").setValue(data.newPath);
         path.child("old").setValue(data.oldPath);
     }


### PR DESCRIPTION
We do not need to know behavior of individuals in the tool, and tracking without user-id is actually a lot simpler in the front-end