### PR TITLE
storing secrets as enviromental variables

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -180,18 +180,19 @@
         <outputDirectory>${project.build.directory}/${project.build.finalName}/WEB-INF/classes</outputDirectory>
 
         <sourceDirectory>src/main/java</sourceDirectory>
-        <testSourceDirectory>src/test/java</testSourceDirectory>
+        <!-- No tests yet -->
+        <!--<testSourceDirectory>src/test/java</testSourceDirectory>-->
 
         <resources>
             <resource>
                 <directory>src/main/resources</directory>
             </resource>
         </resources>
-        <testResources>
-            <testResource>
-                <directory>src/test/resources</directory>
-            </testResource>
-        </testResources>
+        <!--<testResources>-->
+            <!--<testResource>-->
+                <!--<directory>src/test/resources</directory>-->
+            <!--</testResource>-->
+        <!--</testResources>-->
 
         <plugins>
           <plugin>

--- a/src/main/java/previewcode/backend/MainModule.java
+++ b/src/main/java/previewcode/backend/MainModule.java
@@ -103,7 +103,9 @@ public class MainModule extends ServletModule {
     }
 
     private static SecretKeySpec GITHUB_WEBHOOK_SECRET;
-
+    /**
+     * Method to declare Named key "github.webhook.secret" to obtain the webhook secret.
+     */
     @Provides
     @Named("github.webhook.secret")
     public SecretKeySpec provideGitHubWebhookSecret() {
@@ -125,7 +127,9 @@ public class MainModule extends ServletModule {
     }
 
     private static String INTEGRATION_ID;
-
+    /**
+     * Method to declare Named key "integration.id" to obtain the current GitHub Integration id.
+     */
     @Provides
     @Named("integration.id")
     public String provideIntegrationId() {
@@ -141,9 +145,6 @@ public class MainModule extends ServletModule {
         }
         return INTEGRATION_ID;
     }
-
-
-
 
     /**
      * Method to declare Named key "github.user" to obtain the current GitHub instance

--- a/src/main/java/previewcode/backend/api/filter/GitHubAccessTokenFilter.java
+++ b/src/main/java/previewcode/backend/api/filter/GitHubAccessTokenFilter.java
@@ -67,7 +67,6 @@ public class GitHubAccessTokenFilter implements ContainerRequestFilter {
     @Named("integration.id")
     private String INTEGRATION_ID;
 
-
     @Override
     public void filter(ContainerRequestContext containerRequestContext) throws IOException {
         checkForOAuthToken(containerRequestContext);
@@ -94,6 +93,7 @@ public class GitHubAccessTokenFilter implements ContainerRequestFilter {
             try {
                 verifyGitHubWebhookSecret(context, requestBody);
             } catch (Exception e) {
+                logger.warn("Could not verify GitHub webhook call:", e);
                 context.abortWith(UNAUTHORIZED);
                 return;
             }
@@ -150,7 +150,6 @@ public class GitHubAccessTokenFilter implements ContainerRequestFilter {
     private String getGitHubInstallationToken(String requestBody) throws IOException {
         JsonNode body = mapper.readTree(requestBody);
         String installationId = body.get("installation").get("id").asText();
-
 
         Calendar calendar = Calendar.getInstance();
         Date now = calendar.getTime();

--- a/src/main/resources/run-config.xml
+++ b/src/main/resources/run-config.xml
@@ -1,0 +1,44 @@
+<component name="ProjectRunConfigurationManager">
+  <configuration default="false" name="run" type="MavenRunConfiguration" factoryName="Maven">
+    <MavenSettings>
+      <option name="myGeneralSettings" />
+      <option name="myRunnerSettings">
+        <MavenRunnerSettings>
+          <option name="environmentProperties">
+            <map>
+              <entry key="INTEGRATION_ID" value="src/main/resources/integration-id.txt" />
+              <entry key="INTEGRATION_KEY" value="src/main/resources/integration.test-key.pem" />
+              <entry key="WEBHOOK_SECRET" value="src/main/resources/github-webhook-test-secret.txt" />
+            </map>
+          </option>
+          <option name="jreName" value="#USE_PROJECT_JDK" />
+          <option name="mavenProperties">
+            <map />
+          </option>
+          <option name="passParentEnv" value="true" />
+          <option name="runMavenInBackground" value="true" />
+          <option name="skipTests" value="false" />
+          <option name="vmOptions" value="" />
+        </MavenRunnerSettings>
+      </option>
+      <option name="myRunnerParameters">
+        <MavenRunnerParameters>
+          <option name="profiles">
+            <set />
+          </option>
+          <option name="goals">
+            <list>
+              <option value="jetty:run" />
+            </list>
+          </option>
+          <option name="profilesMap">
+            <map />
+          </option>
+          <option name="resolveToWorkspace" value="false" />
+          <option name="workingDirPath" value="$PROJECT_DIR$" />
+        </MavenRunnerParameters>
+      </option>
+    </MavenSettings>
+    <method />
+  </configuration>
+</component>

--- a/src/main/resources/run-config.xml
+++ b/src/main/resources/run-config.xml
@@ -6,9 +6,9 @@
         <MavenRunnerSettings>
           <option name="environmentProperties">
             <map>
-              <entry key="INTEGRATION_ID" value="src/main/resources/integration-id.txt" />
-              <entry key="INTEGRATION_KEY" value="src/main/resources/integration.test-key.pem" />
-              <entry key="WEBHOOK_SECRET" value="src/main/resources/github-webhook-test-secret.txt" />
+              <entry key="INTEGRATION_ID" value="secrets/integration-id.txt" />
+              <entry key="INTEGRATION_KEY" value="secrets/integration.test-key.pem" />
+              <entry key="WEBHOOK_SECRET" value="secrets/github-webhook-test-secret.txt" />
             </map>
           </option>
           <option name="jreName" value="#USE_PROJECT_JDK" />


### PR DESCRIPTION
Uses environmental variables instead of hardcoded paths.

The are configured on the server.
Locally, you have to add them to the run configuration with names:
`INTEGRATION_ID`
`INTEGRATION_KEY`
`WEBHOOK_SECRET`