### PR TITLE
Fix exception mapper

### DIFF
--- a/.idea/runConfigurations/run.xml
+++ b/.idea/runConfigurations/run.xml
@@ -18,7 +18,7 @@
     <module name="backend-api" />
     <envs>
       <env name="INTEGRATION_ID" value="secrets/integration-id.txt" />
-      <env name="INTEGRATION_KEY" value="secrets/integration.test-key.pem" />
+      <env name="INTEGRATION_KEY" value="secrets/integration-test.pkcs8" />
       <env name="WEBHOOK_SECRET" value="secrets/github-webhook-test-secret.txt" />
       <env name="FIREBASE_AUTH" value="secrets/firebase-auth.json" />
       <env name="PORT" value="8443" />

--- a/src/main/java/previewcode/backend/MainModule.java
+++ b/src/main/java/previewcode/backend/MainModule.java
@@ -14,6 +14,7 @@ import org.jboss.resteasy.util.Base64;
 import org.kohsuke.github.GitHub;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import previewcode.backend.api.exceptionmapper.GitHubApiExceptionMapper;
 import previewcode.backend.api.exceptionmapper.IllegalArgumentExceptionMapper;
 import previewcode.backend.api.filter.GitHubAccessTokenFilter;
 import previewcode.backend.api.v1.AssigneesAPI;
@@ -59,6 +60,7 @@ public class MainModule extends ServletModule {
         this.bind(AssigneesAPI.class);
         this.bind(TrackerAPI.class);
         this.bind(IllegalArgumentExceptionMapper.class);
+        this.bind(GitHubApiExceptionMapper.class);
         this.bind(WebhookAPI.class);
 
         try {

--- a/src/main/java/previewcode/backend/api/exceptionmapper/GitHubApiExceptionMapper.java
+++ b/src/main/java/previewcode/backend/api/exceptionmapper/GitHubApiExceptionMapper.java
@@ -1,7 +1,9 @@
 package previewcode.backend.api.exceptionmapper;
 
 import javax.ws.rs.core.Response;
+import javax.ws.rs.ext.Provider;
 
+@Provider
 public class GitHubApiExceptionMapper extends
     AbstractExceptionMapper<GitHubApiException> {
 


### PR DESCRIPTION
so no stack traces will be sent in responses for known exceptions.
When a registered exception occurs, like GitHubApiException, the response error is nicely formatted in JSON