### PR TITLE
Fix global state

### DIFF
--- a/src/main/java/previewcode/backend/MainModule.java
+++ b/src/main/java/previewcode/backend/MainModule.java
@@ -95,7 +95,7 @@ public class MainModule extends ServletModule {
                 String key = Files.toString(file, Charsets.UTF_8)
                         .replace("-----END PRIVATE KEY-----", "")
                         .replace("-----BEGIN PRIVATE KEY-----", "")
-                        .replaceAll("\n", "");
+                        .replaceAll("\n", "").trim();
                 PKCS8EncodedKeySpec keySpec = new PKCS8EncodedKeySpec(Base64.decode(key));
                 KeyFactory kf = KeyFactory.getInstance("RSA");
                 RSA_PRIVATE_KEY = Algorithm.RSA256((RSAPrivateKey) kf.generatePrivate(keySpec));
@@ -120,7 +120,7 @@ public class MainModule extends ServletModule {
             try {
                 logger.info("Loading GitHub Integration Webhook key...");
                 File file = new File(System.getenv("WEBHOOK_SECRET"));
-                final String secret = Files.toString(file, Charsets.UTF_8);
+                final String secret = Files.toString(file, Charsets.UTF_8).trim();
                 GITHUB_WEBHOOK_SECRET = new SecretKeySpec(secret.getBytes(), "HmacSHA1");
             } catch (IOException e) {
                 logger.error("Failed to load GitHub Integration webhook secret:", e);
@@ -141,7 +141,7 @@ public class MainModule extends ServletModule {
     public String provideIntegrationId() {
         try {
             logger.info("Loading GitHub Integration ID...");
-            INTEGRATION_ID = Files.toString(new File(System.getenv("INTEGRATION_ID")), Charsets.UTF_8);
+            INTEGRATION_ID = Files.toString(new File(System.getenv("INTEGRATION_ID")), Charsets.UTF_8).trim();
         } catch (IOException e) {
             logger.error("Failed to load GitHub Integration ID:", e);
             System.exit(-1);

--- a/src/main/java/previewcode/backend/api/filter/GitHubAccessTokenFilter.java
+++ b/src/main/java/previewcode/backend/api/filter/GitHubAccessTokenFilter.java
@@ -100,6 +100,8 @@ public class GitHubAccessTokenFilter implements ContainerRequestFilter {
                 return;
             }
             String installationToken = getGitHubInstallationToken(requestBody);
+            logger.debug("Authenticated as Installation with: " + installationToken.hashCode());
+
             context.setProperty(Key.get(String.class, Names.named(CURRENT_INSTALLATION_TOKEN)).toString(), installationToken);
             GithubService.TokenBuilder builder = (Request.Builder request) ->
                     request
@@ -211,7 +213,7 @@ public class GitHubAccessTokenFilter implements ContainerRequestFilter {
                 final GitHub user = GitHub.connectUsingOAuth(token);
                 context.setProperty(Key.get(GitHub.class, Names.named(CURRENT_USER_NAME)).toString(), user);
                 context.setProperty(Key.get(String.class, Names.named(CURRENT_USER_TOKEN)).toString(), token);
-
+                logger.debug("Authenticated as github user with: " + token.hashCode());
                 GithubService.TokenBuilder builder = (Request.Builder b) -> b.header("Authorization", "token " + token);
                 context.setProperty(Key.get(GithubService.TokenBuilder.class, Names.named(CURRENT_TOKEN_BUILDER)).toString(), builder);
             } catch (final NotAuthorizedException e) {

--- a/src/main/java/previewcode/backend/services/GithubService.java
+++ b/src/main/java/previewcode/backend/services/GithubService.java
@@ -6,9 +6,13 @@ import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.inject.Inject;
 import com.google.inject.Provider;
-import com.google.inject.Singleton;
 import com.google.inject.name.Named;
-import okhttp3.*;
+import com.google.inject.servlet.RequestScoped;
+import okhttp3.MediaType;
+import okhttp3.OkHttpClient;
+import okhttp3.Request;
+import okhttp3.RequestBody;
+import okhttp3.Response;
 import org.kohsuke.github.GHIssueComment;
 import org.kohsuke.github.GHMyself;
 import org.kohsuke.github.GHPullRequest;
@@ -35,12 +39,13 @@ import java.util.Optional;
  * An abstract class that connects with github
  *
  */
-@Singleton
+@RequestScoped
 public class GithubService {
 
     private static final Logger logger = LoggerFactory.getLogger(GithubService.class);
     private static final OkHttpClient OK_HTTP_CLIENT = new OkHttpClient();
     private static final ObjectMapper mapper = new ObjectMapper();
+
 
 
     @Inject
@@ -273,7 +278,7 @@ public class GithubService {
 
     private String execute(Request request) throws IOException, GitHubApiException {
         logger.debug("[OKHTTP3] Executing request: " + request);
-
+        logger.debug("With Authorization hashcode: " + request.header("Authorization").hashCode());
         try (Response response = OK_HTTP_CLIENT.newCall(request).execute()) {
             String body = response.body().string();
             if (response.isSuccessful()) {


### PR DESCRIPTION
Due to `@Singleton` in `GithubService`, the service was only instantiated once, with the first token it gets called with. 

I've added `@RequestScoped` to make the service re-instantiate for each request, and therefore get rid of any global state between requests.

I've also improved logging so we can see which calls use which tokens, but without logging the actual tokens for security reasons.